### PR TITLE
Refactor/use html converter to past

### DIFF
--- a/packages/blocky-core/src/block/basic.ts
+++ b/packages/blocky-core/src/block/basic.ts
@@ -48,23 +48,20 @@ export class BlockPasteEvent extends BlockEvent {
 }
 
 export interface TryParsePastedDOMEventProps {
-  after: CursorState | undefined;
   editor: Editor;
   node: HTMLElement;
 }
 
-// export class TryParsePastedDOMEvent extends BlockEvent {
-//   after: CursorState | undefined;
-//   editor: Editor;
-//   node: HTMLElement;
+export class TryParsePastedDOMEvent extends BlockEvent {
+  editor: Editor;
+  node: HTMLElement;
 
-//   constructor({ after, editor, node }: TryParsePastedDOMEventProps) {
-//     super();
-//     this.after = after;
-//     this.editor = editor;
-//     this.node = node;
-//   }
-// }
+  constructor({ editor, node }: TryParsePastedDOMEventProps) {
+    super();
+    this.editor = editor;
+    this.node = node;
+  }
+}
 
 export interface BlockFocusedEvent {
   selection: Selection;
@@ -118,7 +115,7 @@ export interface IBlockDefinition {
    * or handle it with default handler if no plugins handles.
    *
    */
-  tryParsePastedDOM?(e: TryParsePastedDOMEvent): void;
+  tryParsePastedDOM?(e: TryParsePastedDOMEvent): BlockElement | void;
 
   onBlockCreated(e: BlockCreatedEvent): Block;
 }

--- a/packages/blocky-core/src/block/basic.ts
+++ b/packages/blocky-core/src/block/basic.ts
@@ -20,10 +20,8 @@ export interface CursorDomResult {
 }
 
 export interface BlockPasteEventProps {
-  after: CursorState | undefined;
   editor: Editor;
   node: HTMLElement;
-  tryMerge: boolean;
 }
 
 export class BlockEvent {
@@ -39,17 +37,13 @@ export class BlockEvent {
 }
 
 export class BlockPasteEvent extends BlockEvent {
-  after: CursorState | undefined;
   editor: Editor;
   node: HTMLElement;
-  tryMerge: boolean;
 
-  constructor({ after, editor, node, tryMerge }: BlockPasteEventProps) {
+  constructor({ editor, node }: BlockPasteEventProps) {
     super();
-    this.after = after;
     this.editor = editor;
     this.node = node;
-    this.tryMerge = tryMerge;
   }
 }
 
@@ -59,18 +53,18 @@ export interface TryParsePastedDOMEventProps {
   node: HTMLElement;
 }
 
-export class TryParsePastedDOMEvent extends BlockEvent {
-  after: CursorState | undefined;
-  editor: Editor;
-  node: HTMLElement;
+// export class TryParsePastedDOMEvent extends BlockEvent {
+//   after: CursorState | undefined;
+//   editor: Editor;
+//   node: HTMLElement;
 
-  constructor({ after, editor, node }: TryParsePastedDOMEventProps) {
-    super();
-    this.after = after;
-    this.editor = editor;
-    this.node = node;
-  }
-}
+//   constructor({ after, editor, node }: TryParsePastedDOMEventProps) {
+//     super();
+//     this.after = after;
+//     this.editor = editor;
+//     this.node = node;
+//   }
+// }
 
 export interface BlockFocusedEvent {
   selection: Selection;
@@ -106,7 +100,7 @@ export interface IBlockDefinition {
    * If you want to handle the HTML pasted from another
    * source, please implement [[tryParsePastedDOM]].
    */
-  onPaste?(e: BlockPasteEvent): CursorState | undefined;
+  onPaste?(e: BlockPasteEvent): BlockElement | undefined;
 
   /**
    *

--- a/packages/blocky-core/src/block/textBlock.ts
+++ b/packages/blocky-core/src/block/textBlock.ts
@@ -13,11 +13,10 @@ import {
 } from "./basic";
 import {
   TextType,
-  CursorState,
   BlockyTextModel,
+  BlockyElement,
   type AttributesObject,
   type TextNode,
-  BlockyElement,
 } from "@pkg/model";
 import { areEqualShallow } from "blocky-common/es/object";
 import fastDiff from "fast-diff";

--- a/packages/blocky-core/src/block/textBlock.ts
+++ b/packages/blocky-core/src/block/textBlock.ts
@@ -687,39 +687,11 @@ class TextBlockDefinition implements IBlockDefinition {
   }
 
   onPaste({
-    after: cursorState,
-    node: container,
     editor,
-    tryMerge,
-  }: BlockPasteEvent): CursorState | undefined {
-    if (!cursorState) {
-      return;
-    }
-
-    if (cursorState.type === "open") {
-      return;
-    }
-
-    const currentElement = editor.state.idMap.get(
-      cursorState.targetId
-    )! as BlockElement;
-    const parentElement = currentElement.parent! as BlockyElement;
+    node: container,
+  }: BlockPasteEvent): BlockElement | undefined {
     const newTextElement = this.getTextElementFromDOM(editor, container);
-    const newTextModel = newTextElement.firstChild! as BlockyTextModel;
-
-    if (tryMerge && currentElement.nodeName === TextBlockName) {
-      const oldTextModel = currentElement.firstChild! as BlockyTextModel;
-      oldTextModel.append(newTextModel);
-      return;
-    }
-
-    parentElement.insertAfter(newTextElement, currentElement);
-
-    return {
-      type: "collapsed",
-      targetId: newTextElement.id,
-      offset: 0,
-    };
+    return newTextElement;
   }
 
   /**

--- a/packages/blocky-core/src/helper/htmlConverter.ts
+++ b/packages/blocky-core/src/helper/htmlConverter.ts
@@ -8,7 +8,7 @@ function createTextElement(id: string, content: string): BlockElement {
   const textModel = new BlockyTextModel();
   textModel.insert(0, content);
   const result = new BlockElement(TextBlockName, id);
-  result.appendChild(result);
+  result.appendChild(textModel);
   return result;
 }
 
@@ -24,7 +24,7 @@ function isContainerElement(node: Node): node is HTMLElement {
   return node instanceof HTMLUListElement || node instanceof HTMLDivElement;
 }
 
-export type ElementHandler = (node: Node) => BlockElement | undefined | boolean;
+export type ElementHandler = (node: Node) => BlockElement | void | boolean;
 
 export interface HTMLConverterOptions {
   idGenerator: IdGenerator;

--- a/packages/blocky-core/src/registry/blockRegistry.ts
+++ b/packages/blocky-core/src/registry/blockRegistry.ts
@@ -1,8 +1,9 @@
 import { isUndefined } from "lodash-es";
 import { isUpperCase } from "blocky-common/es/character";
-import {
-  type IBlockDefinition,
-  type TryParsePastedDOMEvent,
+import type {
+  BlockElement,
+  IBlockDefinition,
+  TryParsePastedDOMEvent,
 } from "@pkg/block/basic";
 import { makeTextBlockDefinition, TextBlockName } from "@pkg/block/textBlock";
 
@@ -47,11 +48,11 @@ export class BlockRegistry {
     return this.#nameMap.get(name);
   }
 
-  handlePasteElement(e: TryParsePastedDOMEvent): void {
+  handlePasteElement(e: TryParsePastedDOMEvent): BlockElement | void {
     for (const def of this.#types) {
-      def.tryParsePastedDOM?.(e);
-      if (e.defaultPrevented) {
-        return;
+      const test = def.tryParsePastedDOM?.(e);
+      if (test) {
+        return test;
       }
     }
   }

--- a/packages/blocky-core/src/view/editor.ts
+++ b/packages/blocky-core/src/view/editor.ts
@@ -1171,7 +1171,6 @@ export class Editor {
   pasteHTMLAtCursor(html: string) {
     try {
       const blocks = this.#htmlConverter.parseFromString(html);
-      // TODO: try to merge
       this.#pasteElementsAtCursor(blocks);
     } catch (e) {
       console.error(e);
@@ -1190,7 +1189,25 @@ export class Editor {
     let prev = currentBlockElement;
 
     this.update(() => {
-      for (const element of elements) {
+      for (let i = 0, len = elements.length; i < len; i++) {
+        const element = elements[i];
+
+        if (
+          i === 0 &&
+          currentBlockElement.nodeName === TextBlockName &&
+          element.nodeName === TextBlockName
+        ) {
+          const prevTextModel =
+            currentBlockElement.firstChild! as BlockyTextModel;
+          const firstTextModel = element.firstChild! as BlockyTextModel;
+          if (!prevTextModel || !firstTextModel) {
+            continue;
+          }
+          prevTextModel.append(firstTextModel);
+          // first item, try to merget ext
+          continue;
+        }
+
         parent.insertAfter(element, prev);
         prev = element;
       }

--- a/packages/blocky-core/src/view/editor.ts
+++ b/packages/blocky-core/src/view/editor.ts
@@ -34,7 +34,12 @@ import { BannerDelegate, type BannerFactory } from "./bannerDelegate";
 import { ToolbarDelegate, type ToolbarFactory } from "./toolbarDelegate";
 import { TextBlockName } from "@pkg/block/textBlock";
 import type { EditorController } from "./controller";
-import { Block, BlockElement, BlockPasteEvent } from "@pkg/block/basic";
+import {
+  Block,
+  BlockElement,
+  BlockPasteEvent,
+  TryParsePastedDOMEvent,
+} from "@pkg/block/basic";
 import {
   setTextTypeForTextBlock,
   getTextTypeForTextBlock,
@@ -215,6 +220,16 @@ export class Editor {
 
   #leafHandler = (node: Node): BlockElement | void => {
     const blockRegistry = this.registry.block;
+
+    const tryEvt = new TryParsePastedDOMEvent({
+      editor: this,
+      node: node as HTMLElement,
+    });
+    const testElement = blockRegistry.handlePasteElement(tryEvt);
+    if (testElement) {
+      return testElement;
+    }
+
     const blockDef = blockRegistry.getBlockDefByName(TextBlockName);
     const pasteHandler = blockDef?.onPaste;
     const evt = new BlockPasteEvent({

--- a/packages/blocky-core/src/view/editor.ts
+++ b/packages/blocky-core/src/view/editor.ts
@@ -277,7 +277,7 @@ export class Editor {
     this.state.newBlockCreated.pipe(this.onEveryBlock);
   }
 
-  public drawCollaborativeCursor(
+  drawCollaborativeCursor(
     id: string,
     name: string,
     color: string,
@@ -361,7 +361,7 @@ export class Editor {
     }, 15);
   }
 
-  public render(done?: AfterFn) {
+  render(done?: AfterFn) {
     const newDom = this.#renderer.render(this.#renderedDom);
     if (!this.#renderedDom) {
       this.#container.appendChild(newDom);
@@ -615,7 +615,7 @@ export class Editor {
     this.#selectionChanged();
   };
 
-  public placeBannerAt(blockContainer: HTMLElement, node: BlockElement) {
+  placeBannerAt(blockContainer: HTMLElement, node: BlockElement) {
     const block = this.state.blocks.get(node.id);
     if (!block) {
       return;
@@ -637,7 +637,7 @@ export class Editor {
   /**
    * Remove node and call the destructor
    */
-  public destructBlockNode(node: Node) {
+  destructBlockNode(node: Node) {
     if (node._mgNode) {
       const treeNode = node._mgNode as BlockElement;
 
@@ -814,7 +814,7 @@ export class Editor {
    * fn is called, the render function
    * will be called.
    */
-  public update(fn: () => AfterFn | void, ignoreSelection = false) {
+  update(fn: () => AfterFn | void, ignoreSelection = false) {
     if (this.#isUpdating) {
       throw new Error("is in updating process");
     }
@@ -837,7 +837,7 @@ export class Editor {
     }
   }
 
-  public openExternalLink(link: string) {
+  openExternalLink(link: string) {
     // TODO: handle this in plugin
     window.open(link, "_blank")?.focus();
   }

--- a/packages/blocky-core/src/view/editor.ts
+++ b/packages/blocky-core/src/view/editor.ts
@@ -1171,10 +1171,8 @@ export class Editor {
   pasteHTMLAtCursor(html: string) {
     try {
       const blocks = this.#htmlConverter.parseFromString(html);
+      // TODO: try to merge
       this.#pasteElementsAtCursor(blocks);
-      // const parser = new DOMParser();
-      // const doc = parser.parseFromString(html, MineType.Html);
-      // this.#pasteHTMLBodyOnCursor(doc.body);
     } catch (e) {
       console.error(e);
     }
@@ -1199,147 +1197,6 @@ export class Editor {
     });
   }
 
-  // #pasteHTMLBodyOnCursor(body: HTMLElement) {
-  //   let ptr = body.firstElementChild;
-  //   let afterCursor: CursorState | undefined = this.state.cursorState;
-
-  //   let index = 0;
-  //   while (ptr) {
-  //     const cursor = this.#pasteNodeAt(
-  //       afterCursor,
-  //       ptr as HTMLElement,
-  //       index === 0
-  //     );
-
-  //     if (cursor) {
-  //       afterCursor = cursor;
-  //     }
-
-  //     index++;
-  //     ptr = ptr.nextElementSibling;
-  //   }
-
-  //   this.render(() => {
-  //     this.state.cursorState = afterCursor;
-  //   });
-  // }
-
-  // #tryPasteDivElementAsBlock(
-  //   element: HTMLDivElement,
-  //   cursorState: Cell<CursorState | undefined>
-  // ): BlockElement | void {
-  //   const blockRegistry = this.registry.block;
-  //   const dataType = element.getAttribute("data-type");
-  //   if (!dataType) {
-  //     return;
-  //   }
-  //   const blockDef = blockRegistry.getBlockDefByName(dataType);
-  //   if (!blockDef) {
-  //     return;
-  //   }
-
-  //   const pasteHandler = blockDef?.onPaste;
-  //   if (pasteHandler) {
-  //     const evt = new BlockPasteEvent({
-  //       editor: this,
-  //       node: element,
-  //     });
-  //     return pasteHandler.call(blockDef, evt);
-  //   } else {
-  //     const newCursor = this.#insertBlockByDefaultAt(cursorState.get());
-  //     if (newCursor) {
-  //       cursorState.set(newCursor);
-  //     }
-  //   }
-  // }
-
-  // /**
-  //  *
-  //  * Paste the content of element at the cursor.
-  //  * There is two cases:
-  //  *
-  //  * - Paste the content copied from the editor
-  //  * - Paste the HTML copied from other websites
-  //  *
-  //  * @param tryMerge Indicate whether the content should be merged to the previous block.
-  //  */
-  // #pasteNodeAt(
-  //   cursorState: CursorState | undefined,
-  //   element: HTMLElement,
-  //   tryMerge = false
-  // ): CursorState | undefined {
-  //   const blockRegistry = this.registry.block;
-
-  //   const evt = new TryParsePastedDOMEvent({
-  //     after: cursorState,
-  //     editor: this,
-  //     node: element,
-  //   });
-  //   blockRegistry.handlePasteElement(evt);
-  //   if (evt.defaultPrevented) {
-  //     return evt.after;
-  //   }
-
-  //   if (element instanceof HTMLSpanElement) {
-  //     const attributes: AttributesObject = this.getAttributesBySpan(element);
-  //     let textContent = "";
-
-  //     const testContent = element.textContent;
-  //     if (testContent) {
-  //       textContent = testContent;
-  //     }
-
-  //     return this.#insertTextAt(
-  //       cursorState,
-  //       textContent,
-  //       Object.keys(attributes).length > 0 ? attributes : undefined
-  //     );
-  //   } else if (element instanceof HTMLDivElement) {
-  //     const cursorCell = new Cell(cursorState);
-  //     if (this.#tryPasteDivElementAsBlock(element, cursorCell)) {
-  //       return cursorCell.get();
-  //     } else {
-  //       console.warn("unknown dom:", element);
-  //     }
-  //   } else if (
-  //     element instanceof HTMLParagraphElement ||
-  //     element instanceof HTMLHeadingElement ||
-  //     element instanceof HTMLLIElement
-  //   ) {
-  //     // is a <p> or <h1>
-  //     const blockDef = blockRegistry.getBlockDefByName(TextBlockName);
-  //     const pasteHandler = blockDef?.onPaste;
-  //     const evt = new BlockPasteEvent({
-  //       editor: this,
-  //       node: element,
-  //       tryMerge,
-  //     });
-  //     if (pasteHandler) {
-  //       const cursor = pasteHandler.call(blockDef, evt);
-  //       return cursor;
-  //     } else {
-  //       return this.#insertBlockByDefaultAt(cursorState);
-  //     }
-  //   } else if (element instanceof HTMLUListElement) {
-  //     let childPtr = element.firstElementChild;
-  //     let returnCursor: CursorState | undefined = cursorState;
-
-  //     while (childPtr) {
-  //       returnCursor = this.#pasteNodeAt(
-  //         returnCursor,
-  //         childPtr as HTMLElement,
-  //         false
-  //       );
-  //       childPtr = childPtr.nextElementSibling;
-  //     }
-
-  //     return returnCursor;
-  //   } else {
-  //     console.warn("unknown dom:", element);
-  //   }
-  //   return;
-  // }
-
   /**
    * Calculate the attributes from the dom.
    * It's used for pasting text, and to recognize the dom created by the browser.
@@ -1363,33 +1220,6 @@ export class Editor {
 
     return attributes;
   }
-
-  // #insertBlockByDefaultAt(
-  //   cursorState: CursorState | undefined
-  // ): CursorState | undefined {
-  //   if (!cursorState) {
-  //     return;
-  //   }
-
-  //   if (cursorState.type === "open") {
-  //     return;
-  //   }
-
-  //   const currentNode = this.state.idMap.get(
-  //     cursorState.targetId
-  //   )! as BlockElement;
-
-  //   const textElement = this.state.createTextElement();
-
-  //   const parentElement = currentNode.parent! as BlockyElement;
-  //   parentElement.insertAfter(textElement, currentNode);
-
-  //   return {
-  //     type: "collapsed",
-  //     targetId: textElement.id,
-  //     offset: 0,
-  //   };
-  // }
 
   #pastePlainTextOnCursor(text: string) {
     const cursor = this.#insertTextAt(this.state.cursorState, text);

--- a/packages/blocky-example/src/plugins/imageBlock.tsx
+++ b/packages/blocky-example/src/plugins/imageBlock.tsx
@@ -87,24 +87,16 @@ export function makeImageBlockPlugin(): IPlugin {
           name: ImageBlockName,
           component: (data: BlockElement) => <ImageBlock blockElement={data} />,
           tryParsePastedDOM(e: TryParsePastedDOMEvent) {
-            const { node, editor, after } = e;
+            const { node, editor } = e;
             const img = node.querySelector("img");
-            if (img && after && after.type === "collapsed") {
+            if (img) {
               const newId = editor.idGenerator.mkBlockId();
               const element = new BlockElement(ImageBlockName, newId);
               const src = img.getAttribute("src");
               if (src) {
                 element.setAttribute("src", src);
               }
-              editor.controller.insertBlockAfterId(element, after.targetId, {
-                noRender: true,
-              });
-              e.preventDefault();
-              e.after = {
-                type: "collapsed",
-                targetId: newId,
-                offset: 0,
-              };
+              return element;
             }
           },
         })

--- a/packages/blocky-preact/src/reactBlock.tsx
+++ b/packages/blocky-preact/src/reactBlock.tsx
@@ -16,7 +16,7 @@ import { unmountComponentAtNode } from "preact/compat";
 export interface ReactBlockOptions {
   name: string;
   component: (data: BlockElement) => ComponentChild;
-  tryParsePastedDOM?(e: TryParsePastedDOMEvent): void;
+  tryParsePastedDOM?(e: TryParsePastedDOMEvent): BlockElement | void;
 }
 
 export interface IReactBlockContext {
@@ -29,7 +29,6 @@ export const ReactBlockContext = createContext<IReactBlockContext | undefined>(
 );
 
 class ReactBlock extends Block {
-
   #rendered: HTMLElement | undefined;
 
   constructor(props: BlockElement, private options: ReactBlockOptions) {
@@ -41,7 +40,9 @@ class ReactBlock extends Block {
     this.#rendered = container;
     const editorController = this.editor.controller;
     reactRender(
-      <ReactBlockContext.Provider value={{ editorController, blockId: this.props.id }}>
+      <ReactBlockContext.Provider
+        value={{ editorController, blockId: this.props.id }}
+      >
         {component(this.props)}
       </ReactBlockContext.Provider>,
       container
@@ -51,11 +52,10 @@ class ReactBlock extends Block {
   dispose() {
     if (this.#rendered) {
       unmountComponentAtNode(this.#rendered);
-      this.#rendered = undefined;;
+      this.#rendered = undefined;
     }
     super.dispose();
   }
-
 }
 
 /**


### PR DESCRIPTION
This PR moves the logic of pasting HTML to a class named `HTMLConverter`.